### PR TITLE
Add engines to package.json, drop Node.js v6 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 
 language: node_js
 node_js:
-  - 6
   - 7
   - 8
   - 9
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: 6
 services:
   - mongodb
 sudo: false

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
     "request-promise": "^4.1.1",
     "supertest": "^3.0.0"
   },
+  "engines": {
+    "node": ">=7"
+  },
   "xo": {
     "space": 2,
     "rules": {


### PR DESCRIPTION
At least `yarn` will throw an error if anyone attempts to run with an incompatible version.