### PR TITLE
fix(job): successful callback was reported as error

### DIFF
--- a/src/job.js
+++ b/src/job.js
@@ -66,7 +66,7 @@ const defineJob = ({name, url, method, callback} = {}, jobs, agenda) => {
         }
       })
       .catch(err => job.fail(`failure in callback: ${err.message}`))
-      .then(done);
+      .then(() => done());
   });
 
   jobs.count({name}, (error, count) => {


### PR DESCRIPTION
Before this fix, the job with the callback, would make successful request,
receive the result and report this result as error. That is because in the
promise .then chain, done callback was passed as is. Done callback accepted
error as a first parameter, but was receiving request result in place of error.