### PR TITLE
Fixed command line flag that does not change settings

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const program = require('commander');
-const {app} = require('./dist');
 
 program
   .option('-d, --dbname <dbname>', '[optional] Name of the Mongo database')
@@ -15,6 +14,8 @@ const settings = require('./settings');
 settings.dbname = program.dbname || settings.dbname;
 settings.dbhost = program.dbhost || settings.dbhost;
 settings.timeout = program.timeout || settings.timeout;
+
+const {app} = require('./dist');
 
 app.listen(program.port, () => {
   console.log(`App listening on port ${program.port}.`);


### PR DESCRIPTION
I ran into the same problem with the latest version 0.7.5: #14 
By putting the app require after the settings, it works fine.