### PR TITLE
Add dburi option for full Mongo connection string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ agenda-rest --dbhost localhost --dbname agenda
 |---------------	 |-------------------------------------------------------------------------------------------------------------------------	|
 | **`-d, --dbname`** | [optional] Name of the Mongo database, default is **agenda**                                                            	|
 | **`-h, --dbhost`** | [optional] Mongo instance's IP or domain name, default is **localhost**                                                  |
+| **`-u, --dburi`** | [optional] Full Mongo connection string. If specified, will override **--dbhost**, **--dbname**                                                            	|
 | **`-p, --port`**	 | [optional] agenda-rest server port, default is **4040**                                                                  |
 | **`-k, --key`**  	 | [optional] x-api-key to be expected in headers. If not specified, access to agenda-rest server would be unauthenticated 	|
 | **`-t, --timeout`**| [optional] Timeout for request duration, default is **5000 ms**                                                          |

--- a/cli.js
+++ b/cli.js
@@ -3,6 +3,7 @@
 const program = require('commander');
 
 program
+  .option('-u, --dburi <dburi>', '[optional] Full Mongo connection string')
   .option('-d, --dbname <dbname>', '[optional] Name of the Mongo database')
   .option('-h, --dbhost <dbhost>', '[optional] Mongo instance\'s IP')
   .option('-p, --port <port>', '[optional] Server port, default 4040', (n, d) => Number(n) || d, 4040)
@@ -12,6 +13,7 @@ program
 
 const settings = require('./settings');
 
+settings.dburi = program.dburi || settings.dburi;
 settings.dbname = program.dbname || settings.dbname;
 settings.dbhost = program.dbhost || settings.dbhost;
 settings.appId = program.key || settings.appId;

--- a/settings.js
+++ b/settings.js
@@ -1,5 +1,6 @@
 let dbname = process.env.DB_NAME || 'agenda';
 let dbhost = process.env.DB_HOST || 'localhost';
+let dburi = process.env.DB_URI || null;
 let appId = process.env.API_KEY;
 let collection = 'agendaJobs';
 let definitions = 'jobDefinitions';
@@ -7,13 +8,19 @@ let timeout = 5000;
 
 const settings = {
   get agendaMongoUrl() {
-    return `mongodb://${dbhost}/${dbname}`;
+    return dburi ? dburi : `mongodb://${dbhost}/${dbname}`;
   },
   get dbname() {
     return dbname;
   },
   set dbname(value) {
     dbname = value;
+  },
+  get dburi() {
+    return dburi;
+  },
+  set dburi(value) {
+    dburi = value;
   },
   get dbhost() {
     return dbhost;


### PR DESCRIPTION
This PR simply allows for more complex Mongo connection strings to be passed to Agenda. For instance, when connecting to clusters.