### PR TITLE
Implement options support. Set xo to auto fix lint errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,44 +9,51 @@ Scheduling as a Service, based on [Agenda](https://github.com/agenda/agenda)
 Assuming all job types could be thought of as REST endpoints, scheduling could be offered as a service. `agenda-rest` does just that, introduce a URL, name it, agenda-rest will call it on the times that you specify.
 
 ## Installation
+
 Install agenda-rest as a global package
+
 ```bash
 npm install -g agenda-rest
 ```
 
 ## Usage
+
 To launch the agenda-rest server, use the command line interface specifying the database host name and the database name
+
 ```bash
 agenda-rest --dbhost localhost --dbname agenda
 ```
 
 ## Command Line Interface options
 
-| Options       	 | Description                                                                                                             	|
-|---------------	 |-------------------------------------------------------------------------------------------------------------------------	|
-| **`-d, --dbname`** | [optional] Name of the Mongo database, default is **agenda**                                                            	|
-| **`-h, --dbhost`** | [optional] Mongo instance's IP or domain name, default is **localhost**                                                  |
-| **`-u, --dburi`** | [optional] Full Mongo connection string. If specified, will override **--dbhost**, **--dbname**                                                            	|
-| **`-p, --port`**	 | [optional] agenda-rest server port, default is **4040**                                                                  |
-| **`-k, --key`**  	 | [optional] x-api-key to be expected in headers. If not specified, access to agenda-rest server would be unauthenticated 	|
-| **`-t, --timeout`**| [optional] Timeout for request duration, default is **5000 ms**                                                          |
+| Options             | Description                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **`-d, --dbname`**  | [optional] Name of the Mongo database, default is **agenda**                                                            |
+| **`-h, --dbhost`**  | [optional] Mongo instance's IP or domain name, default is **localhost**                                                 |
+| **`-u, --dburi`**   | [optional] Full Mongo connection string. If specified, will override **--dbhost**, **--dbname**                         |
+| **`-p, --port`**    | [optional] agenda-rest server port, default is **4040**                                                                 |
+| **`-k, --key`**     | [optional] x-api-key to be expected in headers. If not specified, access to agenda-rest server would be unauthenticated |
+| **`-t, --timeout`** | [optional] Timeout for request duration, default is **5000 ms**                                                         |
 
 ## APIs
 
-## API Documentation 
- API Documentation (Postman Generated) available at https://explore.postman.com/templates/4883/agenda-rest  
+## API Documentation
 
+API Documentation (Postman Generated) available at https://explore.postman.com/templates/4883/agenda-rest
 
 ### **GET `/api/job`**
+
 Get a list of defined jobs
 
-* Method: GET
+- Method: GET
 
 ### **POST `/api/job`**
+
 Defines a new category of jobs
 
-* Method: POST
-* Data:
+- Method: POST
+- Data:
+
 ```javascript
 {
     name,           // New job type's name
@@ -61,21 +68,25 @@ Defines a new category of jobs
 ```
 
 ### **PUT `/api/job/:jobName`**
+
 Updates definition of a job category
 
-* Method: PUT
-* Data: same as POST `/api/job`
+- Method: PUT
+- Data: same as POST `/api/job`
 
 ### **DELETE `/api/job/:jobName`**
+
 Deletes job definition and cancels occurrences
 
-* Method: DELETE
+- Method: DELETE
 
 ### **POST `/api/job/once`** & **POST `/api/job/every`**
+
 Schedule a job for single or multiple occurrences
 
-* Method: POST
-* Data:
+- Method: POST
+- Data:
+
 ```javascript
 {
     name,           // Name of the type to create the instance from
@@ -85,11 +96,16 @@ Schedule a job for single or multiple occurrences
         params,     // An object i.e. { param1: 'value1' } used to replace path parameters `http://mydommain.com:3333/test/:param1` => `http://mydommain.com:3333/test/value1` notations in the job definition's url.
         query,      // An object i.e. { foo: 'bar', baz: 'qux' } used to create query parameters (http://mydommain.com:3333/test/value1?foo=bar&baz=qux)
         body        // Accompanying data sent along the request
+    },
+    options: { // (optional) Enables passing options to the `every` method in agenda as documented [here](https://github.com/agenda/agenda#repeateveryinterval-options)
+      timezone, // Specify the job execution timezone.
+      skipImmediate // Don't execute job immidiatly default is `false`.
     }
 }
 ```
 
 Callback, if present, would be invoked by the following object:
+
 ```javascript
 {
     data: {
@@ -100,15 +116,18 @@ Callback, if present, would be invoked by the following object:
 ```
 
 ### **POST `/api/job/now`**
+
 Like `once` and `every`, though without `interval`. Executes the job now.
 
 ### **POST `/api/job/cancel`**
+
 Cancels (not to be confused with 'delete') any jobs matching the query
 
-* Method: POST
-* Data: Mongo query
+- Method: POST
+- Data: Mongo query
+
 ```javascript
 {
-    name: "foo"
+  name: "foo";
 }
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "jsnext:main": "./src/index.js",
   "scripts": {
     "prepublish": "npm run build",
-    "lint": "xo",
+    "lint": "xo --fix",
     "dev": "webpack --mode development",
     "build": "webpack --mode production",
     "test": "ava dist/test.js && npm run lint",

--- a/src/job.js
+++ b/src/job.js
@@ -1,8 +1,6 @@
-import querystring from 'querystring';
-import {items} from 'pythonic';
 import rp from 'request-promise';
 import settings from '../settings';
-import {isValidDate} from './util';
+import {isValidDate, buildUrlWithParams, buildUrlWithQuery} from './util';
 
 const getCheckJobFormatFunction = (jobProperty, defaultJob = {}) => job => {
   if (!job.name || (jobProperty && !job[jobProperty])) {
@@ -43,29 +41,8 @@ const defineJob = async (job, jobs, agenda) => {
     const {
       attrs: {data}
     } = job;
-    let uri = url;
-    // http://example.com:8888/foo/:param1/:param2
-    // =>
-    // http://example.com:8888/foo/value1/value2
-    if (url.indexOf('/:') > 0 && data.params) {
-      const protoDomain = url.slice(0, url.indexOf('/:'));
-      let path = url.slice(url.indexOf('/:'));
-      for (const [key, value] of items(data.params)) {
-        path = path.replace(`:${key}`, value);
-      }
-
-      uri = `${protoDomain}${path}`;
-    }
-
-    // http://example.com/foo
-    // =>
-    // http://example.com/foo?query1=value1&query2=value2
-    if (data.query) {
-      const query = querystring.stringify(data.query);
-      if (query !== '') {
-        uri += `?${query}`;
-      }
-    }
+    let uri = buildUrlWithParams({url, params: data.params});
+    uri = buildUrlWithQuery({url: uri, query: data.query});
 
     const options = {
       method: method || 'POST',

--- a/src/job.js
+++ b/src/job.js
@@ -129,13 +129,16 @@ const getDefaultJobForSchedule = () => ({
   }
 });
 
-const pickValues = job => (props, prop) =>
-  job[prop] ? [...props, job[prop]] : props;
+const pickValues = ({job, pickProps}) =>
+  pickProps.reduce(
+    (props, prop) => (job[prop] ? [...props, job[prop]] : props),
+    []
+  );
 const scheduleTypes = {
   now: {
     fn: agenda => agenda.now.bind(agenda),
     message: 'for now',
-    getParams: job => ['name', 'data'].reduce(pickValues(job), [])
+    getParams: job => pickValues({job, pickProps: ['name', 'data']})
   },
   once: {
     fn: agenda => agenda.schedule.bind(agenda),
@@ -147,14 +150,17 @@ const scheduleTypes = {
       // Check if interval is date
       time = new Date(time);
       time = isValidDate(time) ? time : job.interval;
-      return ['time', 'name', 'data'].reduce(pickValues({...job, time}), []);
+      return pickValues({
+        job: {...job, time},
+        pickProps: ['time', 'name', 'data']
+      });
     }
   },
   every: {
     fn: agenda => agenda.every.bind(agenda),
     message: 'for repetition',
     getParams: job =>
-      ['interval', 'name', 'data', 'options'].reduce(pickValues(job), [])
+      pickValues({job, pickProps: ['interval', 'name', 'data', 'options']})
   }
 };
 

--- a/src/job.js
+++ b/src/job.js
@@ -1,25 +1,25 @@
-import querystring from 'querystring';
-import {items} from 'pythonic';
-import rp from 'request-promise';
-import settings from '../settings';
-import {isValidDate} from './util';
+import querystring from "querystring";
+import { items } from "pythonic";
+import rp from "request-promise";
+import settings from "../settings";
+import { isValidDate } from "./util";
 
 const getCheckJobFormatFunction = (jobProperty, defaultJob = {}) => job => {
   if (!job.name || (jobProperty && !job[jobProperty])) {
     throw new Error(
       `expected request body to match {name${
-        jobProperty ? `, ${jobProperty}` : ''
+        jobProperty ? `, ${jobProperty}` : ""
       }}`
     );
   }
 
-  return {...defaultJob, ...job};
+  return { ...defaultJob, ...job };
 };
 
 const doNotCheck = job => job;
 
 const getAssertFunction = (assertOnCount, errorOnName) => (job, jobs) =>
-  jobs.countDocuments({name: job.name}).then(count => {
+  jobs.countDocuments({ name: job.name }).then(count => {
     if (!assertOnCount(count)) {
       throw new Error(errorOnName(job.name));
     }
@@ -38,18 +38,18 @@ const jobAssertions = {
 };
 
 const defineJob = async (job, jobs, agenda) => {
-  const {name, url, method, callback} = job;
+  const { name, url, method, callback } = job;
   agenda.define(name, (job, done) => {
     const {
-      attrs: {data}
+      attrs: { data }
     } = job;
     let uri = url;
     // http://example.com:8888/foo/:param1/:param2
     // =>
     // http://example.com:8888/foo/value1/value2
-    if (url.indexOf('/:') > 0 && data.params) {
-      const protoDomain = url.slice(0, url.indexOf('/:'));
-      let path = url.slice(url.indexOf('/:'));
+    if (url.indexOf("/:") > 0 && data.params) {
+      const protoDomain = url.slice(0, url.indexOf("/:"));
+      let path = url.slice(url.indexOf("/:"));
       for (const [key, value] of items(data.params)) {
         path = path.replace(`:${key}`, value);
       }
@@ -62,13 +62,13 @@ const defineJob = async (job, jobs, agenda) => {
     // http://example.com/foo?query1=value1&query2=value2
     if (data.query) {
       const query = querystring.stringify(data.query);
-      if (query !== '') {
+      if (query !== "") {
         uri += `?${query}`;
       }
     }
 
     const options = {
-      method: method || 'POST',
+      method: method || "POST",
       uri,
       body: data.body,
       headers: data.headers || {},
@@ -78,21 +78,21 @@ const defineJob = async (job, jobs, agenda) => {
     // Error if no response in timeout
     Promise.race([
       new Promise((resolve, reject) =>
-        setTimeout(() => reject(new Error('TimeOutError')), settings.timeout)
+        setTimeout(() => reject(new Error("TimeOutError")), settings.timeout)
       ),
       rp(options)
     ])
       .catch(err => {
         job.fail(`options: ${JSON.stringify(options)} message: ${err.message}`);
-        return {error: err.message};
+        return { error: err.message };
       })
       .then(result => {
         if (callback) {
           return rp({
-            method: callback.method || 'POST',
+            method: callback.method || "POST",
             uri: callback.url,
             headers: callback.headers || {},
-            body: {data, response: result},
+            body: { data, response: result },
             json: true
           });
         }
@@ -102,12 +102,12 @@ const defineJob = async (job, jobs, agenda) => {
   });
 
   await jobs
-    .countDocuments({name})
+    .countDocuments({ name })
     .then(count =>
-      count < 1 ? jobs.insertOne(job) : jobs.updateOne({name}, {$set: job})
+      count < 1 ? jobs.insertOne(job) : jobs.updateOne({ name }, { $set: job })
     );
 
-  return 'job defined';
+  return "job defined";
 };
 
 const deleteJob = async (job, jobs, agenda) => {
@@ -129,20 +129,20 @@ const getDefaultJobForSchedule = () => ({
   }
 });
 
-const pickValues = ({job, pickProps}) =>
+const pickValues = ({ obj, pickProps }) =>
   pickProps.reduce(
-    (props, prop) => (job[prop] ? [...props, job[prop]] : props),
+    (props, prop) => (obj[prop] ? [...props, obj[prop]] : props),
     []
   );
 const scheduleTypes = {
   now: {
     fn: agenda => agenda.now.bind(agenda),
-    message: 'for now',
-    getParams: job => pickValues({job, pickProps: ['name', 'data']})
+    message: "for now",
+    getParams: job => pickValues({ obj: job, pickProps: ["name", "data"] })
   },
   once: {
     fn: agenda => agenda.schedule.bind(agenda),
-    message: 'for once',
+    message: "for once",
     getParams: job => {
       // Check if interval is timestamp
       let time = parseInt(job.interval, 10);
@@ -151,16 +151,19 @@ const scheduleTypes = {
       time = new Date(time);
       time = isValidDate(time) ? time : job.interval;
       return pickValues({
-        job: {...job, time},
-        pickProps: ['time', 'name', 'data']
+        obj: { ...job, time },
+        pickProps: ["time", "name", "data"]
       });
     }
   },
   every: {
     fn: agenda => agenda.every.bind(agenda),
-    message: 'for repetition',
+    message: "for repetition",
     getParams: job =>
-      pickValues({job, pickProps: ['interval', 'name', 'data', 'options']})
+      pickValues({
+        obj: job,
+        pickProps: ["interval", "name", "data", "options"]
+      })
   }
 };
 
@@ -175,7 +178,7 @@ const getJobOperation = (checkFunction, jobFunction) => ({
 });
 
 const jobOperations = {
-  create: getJobOperation(getCheckJobFormatFunction('url'), defineJob),
+  create: getJobOperation(getCheckJobFormatFunction("url"), defineJob),
   update: getJobOperation(getCheckJobFormatFunction(), defineJob),
   delete: getJobOperation(getCheckJobFormatFunction(), deleteJob),
   cancel: getJobOperation(doNotCheck, cancelJob),
@@ -184,11 +187,11 @@ const jobOperations = {
     getScheduleJobFunction(scheduleTypes.now)
   ),
   once: getJobOperation(
-    getCheckJobFormatFunction('interval', getDefaultJobForSchedule()),
+    getCheckJobFormatFunction("interval", getDefaultJobForSchedule()),
     getScheduleJobFunction(scheduleTypes.once)
   ),
   every: getJobOperation(
-    getCheckJobFormatFunction('interval', getDefaultJobForSchedule()),
+    getCheckJobFormatFunction("interval", getDefaultJobForSchedule()),
     getScheduleJobFunction(scheduleTypes.every)
   )
 };
@@ -205,4 +208,4 @@ const promiseJobOperation = async (
   return jobOperation.fn(job, jobs, agenda);
 };
 
-export {promiseJobOperation, jobOperations, jobAssertions, defineJob};
+export { promiseJobOperation, jobOperations, jobAssertions, defineJob };

--- a/src/util.js
+++ b/src/util.js
@@ -2,28 +2,34 @@ import Koa from 'koa';
 import logger from 'koa-logger';
 import Router from 'koa-router';
 import bodyParser from 'koa-bodyparser';
+import {items} from 'pythonic';
+import querystring from 'querystring';
 
 const bootstrapKoaApp = () => {
   const app = new Koa();
   const router = new Router();
   app.use(logger());
-  app.use((ctx, next) => next()
-    .catch(error => {
+  app.use((ctx, next) =>
+    next().catch(error => {
       console.dir(error);
       ctx.body = String(error);
       ctx.status = error.status || 500;
     })
   );
-  app.use(bodyParser({
-    onerror(error, ctx) {
-      ctx.throw(400, `cannot parse request body, ${JSON.stringify(error)}`);
-    }
-  }));
+  app.use(
+    bodyParser({
+      onerror(error, ctx) {
+        ctx.throw(400, `cannot parse request body, ${JSON.stringify(error)}`);
+      }
+    })
+  );
   app.use(router.routes());
   return {app, router};
 };
 
-const isValidDate = date => Object.prototype.toString.call(date) === '[object Date]' && !isNaN(date.getTime());
+const isValidDate = date =>
+  Object.prototype.toString.call(date) === '[object Date]' &&
+  !isNaN(date.getTime());
 
 const repeatPerKey = (keys = {}) => count => (key, fn) => () => {
   if (!(key in keys)) {
@@ -60,4 +66,42 @@ class AsyncCounter {
   }
 }
 
-export {bootstrapKoaApp, isValidDate, oncePerKey, AsyncCounter};
+// http://example.com:8888/foo/:param1/:param2
+// =>
+// http://example.com:8888/foo/value1/value2
+const buildUrlWithParams = ({url, params}) => {
+  if (url.indexOf('/:') > 0 && params) {
+    const protoDomain = url.slice(0, url.indexOf('/:'));
+    let path = url.slice(url.indexOf('/:'));
+    for (const [key, value] of items(params)) {
+      path = path.replace(`:${key}`, value);
+    }
+
+    return `${protoDomain}${path}`;
+  }
+
+  return url;
+};
+
+// http://example.com/foo
+// =>
+// http://example.com/foo?query1=value1&query2=value2
+const buildUrlWithQuery = ({url, query}) => {
+  if (query) {
+    query = querystring.stringify(query);
+    if (query !== '') {
+      url += `?${query}`;
+    }
+  }
+
+  return url;
+};
+
+export {
+  bootstrapKoaApp,
+  isValidDate,
+  oncePerKey,
+  AsyncCounter,
+  buildUrlWithParams,
+  buildUrlWithQuery
+};

--- a/test.js
+++ b/test.js
@@ -1,21 +1,29 @@
 const {promisify} = require('util');
 const test = require('ava');
 const request = require('supertest');
-const {bootstrapKoaApp, oncePerKey, AsyncCounter} = require('./src/util');
+const {
+  bootstrapKoaApp,
+  oncePerKey,
+  AsyncCounter,
+  buildUrlWithParams,
+  buildUrlWithQuery
+} = require('./src/util');
 
 const agendaAppUrl = 'http://localhost:4041';
 const testAppUrl = 'http://localhost:4042';
 const {app: testApp, router: testAppRouter} = bootstrapKoaApp();
-const getTestAppUrl = path => path ? `${testAppUrl}${path}` : testAppUrl;
+const getTestAppUrl = path => (path ? `${testAppUrl}${path}` : testAppUrl);
 
 const agendaAppRequest = request(agendaAppUrl);
 
 const bootstrapApp = async () => {
   const {app, jobsReady} = require('./src');
-  await promisify(app.listen).bind(app)(4041)
+  await promisify(app.listen)
+    .bind(app)(4041)
     .then(() => console.log('agenda-rest app running'));
 
-  await promisify(testApp.listen).bind(testApp)(4042)
+  await promisify(testApp.listen)
+    .bind(testApp)(4042)
     .then(() => console.log('test app running'));
   await jobsReady;
 };
@@ -23,9 +31,7 @@ const bootstrapApp = async () => {
 test.before(() => bootstrapApp());
 
 test.serial('POST /api/job fails without content', async t => {
-  const res = await agendaAppRequest
-    .post('/api/job')
-    .send();
+  const res = await agendaAppRequest.post('/api/job').send();
 
   t.is(res.status, 400);
 });
@@ -56,18 +62,29 @@ test.serial('PUT /api/job succeeds when the job exists', async t => {
 
 const fooProps = {};
 
-const defineFooEndpoint = (route, message, countTimes = 1, statusCode = 200) => {
+const defineFooEndpoint = (
+  route,
+  message,
+  countTimes = 1,
+  statusCode = 200
+) => {
   const counter = new AsyncCounter(countTimes);
   fooProps.counter = counter;
   fooProps.message = message;
   fooProps.statusCode = statusCode;
 
-  const define = oncePerKey(route, () => testAppRouter.post(route, async (ctx, next) => {
-    ctx.body = fooProps.message;
-    ctx.status = fooProps.statusCode;
-    console.log(`${fooProps.message}! ${await fooProps.counter.count()} of ${fooProps.counter.countTimes}`);
-    await next();
-  }));
+  const define = oncePerKey(route, () =>
+    testAppRouter.post(route, async (ctx, next) => {
+      ctx.body = fooProps.message;
+      ctx.status = fooProps.statusCode;
+      console.log(
+        `${fooProps.message}! ${await fooProps.counter.count()} of ${
+          fooProps.counter.countTimes
+        }`
+      );
+      await next();
+    })
+  );
   define();
   return counter;
 };
@@ -90,43 +107,71 @@ testAppRouter.post('/foo/cb', async (ctx, next) => {
 });
 */
 
-test.serial('POST /api/job/now with existing foo definition invokes the foo endpoint', async t => {
-  const counter = defineFooEndpoint('/foo', 'foo now invoked');
-  const res = await agendaAppRequest
-    .post('/api/job/now')
-    .send({name: 'foo'});
+test.serial(
+  'POST /api/job/now with existing foo definition invokes the foo endpoint',
+  async t => {
+    const counter = defineFooEndpoint('/foo', 'foo now invoked');
+    const res = await agendaAppRequest
+      .post('/api/job/now')
+      .send({name: 'foo'});
 
-  t.is(res.text, 'job scheduled for now');
+    t.is(res.text, 'job scheduled for now');
 
-  await counter.finished;
-});
+    await counter.finished;
+  }
+);
 
-test.serial('POST /api/job/every with existing foo definition invokes the foo endpoint', async t => {
-  const counter = defineFooEndpoint('/foo', 'foo every invoked', 3);
-  const res = await agendaAppRequest
-    .post('/api/job/every')
-    .send({name: 'foo', interval: '2 seconds'});
+test.serial(
+  'POST /api/job/every with existing foo definition invokes the foo endpoint',
+  async t => {
+    const counter = defineFooEndpoint('/foo', 'foo every invoked', 3);
+    const res = await agendaAppRequest
+      .post('/api/job/every')
+      .send({name: 'foo', interval: '2 seconds'});
 
-  t.is(res.text, 'job scheduled for repetition');
+    t.is(res.text, 'job scheduled for repetition');
 
-  await counter.finished;
-});
+    await counter.finished;
+  }
+);
 
-test.serial('POST /api/job/once with existing foo definition invokes the foo endpoint', async t => {
-  const counter = defineFooEndpoint('/foo', 'foo once invoked');
-  const res = await agendaAppRequest
-    .post('/api/job/once')
-    .send({name: 'foo', interval: new Date().getTime() + 10000});
+test.serial(
+  'POST /api/job/once with existing foo definition invokes the foo endpoint',
+  async t => {
+    const counter = defineFooEndpoint('/foo', 'foo once invoked');
+    const res = await agendaAppRequest
+      .post('/api/job/once')
+      .send({name: 'foo', interval: new Date().getTime() + 10000});
     // .send({name: 'foo', interval: 'in 10 seconds'});
 
-  t.is(res.text, 'job scheduled for once');
+    t.is(res.text, 'job scheduled for once');
 
-  await counter.finished;
-});
+    await counter.finished;
+  }
+);
 
 test.serial('DELETE /api/job succeeds when a job is defined', async t => {
-  const res = await agendaAppRequest
-    .delete('/api/job/foo');
+  const res = await agendaAppRequest.delete('/api/job/foo');
 
   t.is(res.status, 200);
+});
+
+test('Build URL with parameters.', t => {
+  t.is(
+    buildUrlWithParams({
+      url: 'http://example.com:8888/foo/:param1/:param2',
+      params: {param1: 'value1', param2: 'value2'}
+    }),
+    'http://example.com:8888/foo/value1/value2'
+  );
+});
+
+test('Build URL with query.', t => {
+  t.is(
+    buildUrlWithQuery({
+      url: 'http://example.com/foo',
+      query: {query1: 'value1', query2: 'value2'}
+    }),
+    'http://example.com/foo?query1=value1&query2=value2'
+  );
 });


### PR DESCRIPTION
Fixes #72 

- Implement options support.
- Set xo to auto fix lint errors.

Example payload with options:

```js
    let payload = {
      name: sourceID,
      interval: `0 ${_.join(',', frequency)} * * *`,
      data: {
        body: { event, action },
      },
      options: {
        skipImmediate: false,
        timezone: 'America/New_York',
      },
    }
```
- Added unit tests for building URLs with parameters and query.